### PR TITLE
Minor dependency updates

### DIFF
--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.11.2
+    rev: v0.11.5
     hooks:
       # Run the linter.
       - id: ruff
@@ -12,13 +12,13 @@ repos:
   # Keep uv.lock up-to-date.
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.6.10
+    rev: 0.6.14
     hooks:
       - id: uv-lock
 
   # Prevent secrets from being committed.
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.24.2
+    rev: v8.24.3
     hooks:
       - id: gitleaks
   

--- a/{{cookiecutter.project_name}}/Dockerfile
+++ b/{{cookiecutter.project_name}}/Dockerfile
@@ -1,7 +1,7 @@
 # Set-up uv and copy project files
 FROM python:{{cookiecutter.python_version}}-slim-bookworm
-# Pin uv version 0.6.10
-COPY --from=ghcr.io/astral-sh/uv:0.6.10 /uv /uvx /bin/
+# Pin uv version 0.6.14
+COPY --from=ghcr.io/astral-sh/uv:0.6.14 /uv /uvx /bin/
 
 WORKDIR /app
 


### PR DESCRIPTION
This pull request introduces minor version updates in both `pre-commit` hooks and the `Dockerfile`

- `pre-commit`: Update the version of `ruff`, `uv` and `gitleaks`
- `Dockerfile`: Pinned to the latest `uv` version