### PR TITLE
Refine `cookiecutter` options + dependency updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ and running for:
 
 - `uv` to manage packages and Python installations
 - `pytest` for unit-testing
-- `pre-commit`:
+- GitHub action to execute tests.
+- [Optional] `pre-commit`:
     - `ruff` hook to format and lint code
     - `uv` hook to keep `uv.lock` up-to date
     - `gitleaks` hook to prevent you from committing secrets (API keys, etc.)
-- GitHub action to execute tests.
 - [Optional] Docker template (with Python and `uv`)
 
 > [!NOTE]

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,6 +4,7 @@
   "project_name": "my-project",
   "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}",
   "project_description": "Short description of your project.",
-  "python_version": "3.12",
-  "use_docker": "n"
+  "python_version": ["3.13", "3.12", "3.11", "3.10", "3.9", "3.8", "3.7"],
+  "use_precommit": ["yes", "no"],
+  "use_docker": ["yes", "no"]
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,7 +4,7 @@
   "project_name": "my-project",
   "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}",
   "project_description": "Short description of your project.",
-  "python_version": ["3.13", "3.12", "3.11", "3.10", "3.9", "3.8", "3.7"],
+  "python_version": ["3.13", "3.12", "3.11", "3.10", "3.9"],
   "use_precommit": ["yes", "no"],
   "use_docker": ["yes", "no"]
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -2,12 +2,18 @@ import subprocess
 from pathlib import Path
 
 subprocess.run(["git", "init"])
-subprocess.run(["pre-commit", "autoupdate"])
-subprocess.run(["pre-commit", "install", "--install-hooks"])
+
+if "{{ cookiecutter.use_precommit }}" == "yes":
+    subprocess.run(["pre-commit", "autoupdate"])
+    subprocess.run(["pre-commit", "install", "--install-hooks"])
+
+else:
+    Path(".pre-commit-config.yaml").unlink()
+
 subprocess.run(["uv", "sync"])
 
 # remove all Docker files
-if "{{ cookiecutter.use_docker }}" == "n":
+if "{{ cookiecutter.use_docker }}" == "no":
     Path("docker-compose.yaml").unlink()
     Path("Dockerfile").unlink()
     Path(".dockerignore").unlink()

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.11.11
+    rev: v0.12.1
     hooks:
       # Run the linter.
       - id: ruff
@@ -12,13 +12,13 @@ repos:
   # Keep uv.lock up-to-date.
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.7.8
+    rev: 0.7.19
     hooks:
       - id: uv-lock
 
   # Prevent secrets from being committed.
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.26.0
+    rev: v8.27.2
     hooks:
       - id: gitleaks
   

--- a/{{cookiecutter.project_name}}/Dockerfile
+++ b/{{cookiecutter.project_name}}/Dockerfile
@@ -1,7 +1,7 @@
 # Set-up uv and copy project files
 FROM python:{{cookiecutter.python_version}}-slim-bookworm
 # Pin uv version 0.7.8
-COPY --from=ghcr.io/astral-sh/uv:0.7.8 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.7.19 /uv /uvx /bin/
 
 WORKDIR /app
 

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = []
 
 [dependency-groups]
 dev = [
-    "pytest>=8.3.5",
+    "pytest>=8.4.1",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
This pull request introduces several updates to improve configurability and mitigate errors during the project set-up. Additional dependency updates were made.

### Configuration enhancements:
* `cookiecutter.json`: Fixed Python versions (`3.13`, `3.12`, `3.11`, `3.10`, `3.9`). Other versions are either not supported by `uv` or `pytest`. This prevents errors during the set-up process.
* Set `pre-commit` optional: If you're just setting up a project to quickly test things. Setting this option to `"no"` quite significantly speeds up the project generation process!
* Usage of Docker: Now has 2 options (yes or no) instead of free user input.

### Dependency updates:
* `.pre-commit-config.yaml` Updated versions for `ruff` (v0.12.1), `uv` (0.7.19), and `gitleaks` (v8.27.2).
* `Dockerfile`: Updated `uv` version from `0.7.8` to `0.7.19`.
* `pyproject.toml`: Updated `pytest` dependency to version `8.4.1`.
