### PR TITLE
Python 3.14 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ cookiecutter https://github.com/JakobKlotz/python-template.git
 structure creation, the virtual environment and `pre-commit` hooks are 
 automatically installed. 🚀
 
+## 3️⃣ [Optional] Run First Script
+
+To execute the pre-bundled script, simply use:
+
+```bash
+uv run main.py
+```
+
+The script just prints the current Python version.
+
 ## Contributions
 
 Any contributions are welcome! 👋🏽 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,7 +4,7 @@
   "project_name": "my-project",
   "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}",
   "project_description": "Short description of your project.",
-  "python_version": ["3.13", "3.12", "3.11", "3.10", "3.9"],
+  "python_version": ["3.14", "3.13", "3.12", "3.11", "3.10"],
   "use_precommit": ["yes", "no"],
   "use_docker": ["yes", "no"]
 }

--- a/{{cookiecutter.project_name}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_name}}/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.12.12
+    rev: v0.14.0
     hooks:
       # Run the linter.
-      - id: ruff
+      - id: ruff-check
         args: [ --fix ]
       # Run the formatter.
       - id: ruff-format
@@ -12,8 +12,9 @@ repos:
   # Keep uv.lock up-to-date.
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
-    rev: 0.8.15
+    rev: 0.9.1
     hooks:
+      # Update the uv lockfile
       - id: uv-lock
 
   # Prevent secrets from being committed.

--- a/{{cookiecutter.project_name}}/main.py
+++ b/{{cookiecutter.project_name}}/main.py
@@ -1,0 +1,3 @@
+import sys
+
+print("Hello from your template!\n" f"Running Python {sys.version}")

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = []
 
 [dependency-groups]
 dev = [
-    "pytest>=8.4.1",
+    "pytest>=8.4.2",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
- Support for Python 3.14
- Removed Python 3.9 since its at the end of support
- Added a small entrypoint script that prints the current Python version
- Updated `pre-commit` hooks